### PR TITLE
Fixing Dockerfile build process

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -92,7 +92,7 @@ jobs:
     # Run the image from the base entrypoint as a test
     - name: Test container with entrypoint
       # Run a tag we generated from the metadata extraction above -- they're all the same image, but echo it regardless just so we know.
-      run: ls -lt; ls -lt /work; docker run --rm --entrypoint="mkdir bin; cmake -DITK_DIR=/work/CaPTK/bin/ITK-build -DDCMTK_DIR=/work/CaPTK/bin/DCMTK-build -DCMAKE_INSTALL_PREFIX="./install/appdir/usr" -DBUILD_TESTING=OFF ..; make && make install/strip;" -v "$(pwd)"/Front-End:/Front-End ghcr.io/fets-ai/front-end:latest
+      run: docker run --rm ghcr.io/fets-ai/front-end:latest
 
     # Push Docker image with Buildx (but don't push on PR)
     # https://github.com/docker/build-push-action

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,8 @@ COPY . .
 
 RUN echo "running ls -l" && ls -l && pwd
 
+RUN bash ./buildscript.sh
+
 # set up the docker for GUI
 ENV QT_X11_NO_MITSHM=1
 ENV QT_GRAPHICSSYSTEM="native"

--- a/buildscript.sh
+++ b/buildscript.sh
@@ -1,0 +1,13 @@
+
+mkdir -p ./bin
+cd ./bin
+
+echo "Exporting environment variables"
+export PATH=/opt/qt/5.11.2/gcc_64/bin:/opt/qt/5.11.2/gcc_64/libexec:$PATH
+export CMAKE_PREFIX_PATH=/work/CaPTk/bin/ITK-build:/work/CaPTk/bin/DCMTK-build:/opt/qt/5.11.2/gcc_64/lib/cmake/Qt5:$CMAKE_PREFIX_PATH
+
+echo "Running CMake"
+cmake -DCMAKE_INSTALL_PREFIX="./install/appdir/usr" -DITK_DIR="/work/CaPTk/bin/ITK-build" -DDCMTK_DIR="/work/CaPTk/bin/DCMTK-build" -DBUILD_TESTING=OFF ..
+
+echo "Running make + install"
+make -j4 && make install/strip

--- a/src/applications/CMakeLists.txt
+++ b/src/applications/CMakeLists.txt
@@ -124,7 +124,8 @@ IF (BUILD_DEEPMEDIC)
   SET( CAPTK_APP_LIST_PY_GUI "${CAPTK_APP_LIST_PY_GUI} deepmedic" CACHE STRING "Available stand-alone apps" FORCE)
   ### this should be removed and put in with application decoupling
   ## this is a TEMPORARY work-around until https://github.com/CBICA/CaPTk/pull/1043 is merged
-  SET( DOWNLOAD_LINK "ftp://www.nitrc.org/home/groups/captk/downloads/deepMedicInference_${PLATFORM_STRING}.zip" )
+  #SET( DOWNLOAD_LINK "ftp://www.nitrc.org/home/groups/captk/downloads/deepMedicInference_${PLATFORM_STRING}.zip" )
+  SET( DOWNLOAD_LINK "https://captk.projects.nitrc.org/deepMedicInference_${PLATFORM_STRING}.zip" )
   SET( FILENAME_TO_EXTRACT "deepMedicInference_${PLATFORM_STRING}")
   SET( FILE_TO_EXTRACT ${PROJECT_BINARY_DIR}/${FILENAME_TO_EXTRACT}.zip)
 
@@ -187,8 +188,9 @@ FOREACH(subdir ${SUBDIRECTORIES})
     SET( CAPTK_APP_LIST_PY_GUI "${CAPTK_APP_LIST_PY_GUI} deepmedic" CACHE STRING "Available stand-alone apps" FORCE)
     ### this should be removed and put in with application decoupling
     ## this is a TEMPORARY work-around until https://github.com/CBICA/CaPTk/pull/1043 is merged
-    SET( DOWNLOAD_LINK "ftp://www.nitrc.org/home/groups/captk/downloads/deepMedicInference_${PLATFORM_STRING}.zip" )
-    SET( FILENAME_TO_EXTRACT "deepMedicInference_${PLATFORM_STRING}")
+    #SET( DOWNLOAD_LINK "ftp://www.nitrc.org/home/groups/captk/downloads/deepMedicInference_${PLATFORM_STRING}.zip" )
+    SET( DOWNLOAD_LINK "https://captk.projects.nitrc.org/deepMedicInference_${PLATFORM_STRING}.zip" )
+	SET( FILENAME_TO_EXTRACT "deepMedicInference_${PLATFORM_STRING}")
     SET( FILE_TO_EXTRACT ${PROJECT_BINARY_DIR}/${FILENAME_TO_EXTRACT}.zip)
     
     SET( DOWNLOADED_APPS_DIR ${PROJECT_BINARY_DIR}/deepMedicInference )
@@ -273,7 +275,8 @@ IF( NOT EXISTS "${SOURCE_APPLICATIONS_PATH}/dcm2niix" )
 ENDIF()
 
 #specify download link
-SET( DOWNLOAD_LINK "ftp://www.nitrc.org/home/groups/captk/downloads/precompiledApps/dcm2niix_${PLATFORM_STRING}.zip" )
+#SET( DOWNLOAD_LINK "ftp://www.nitrc.org/home/groups/captk/downloads/precompiledApps/dcm2niix_${PLATFORM_STRING}.zip" )
+SET( DOWNLOAD_LINK "https://captk.projects.nitrc.org/dcm2niix_${PLATFORM_STRING}.zip" )
 SET( FILENAME_TO_EXTRACT "dcm2niix_${PLATFORM_STRING}")
 SET( FILE_TO_EXTRACT ${PROJECT_BINARY_DIR}/${FILENAME_TO_EXTRACT}.zip)
 

--- a/src/applications/Utilities/CMakeLists.txt
+++ b/src/applications/Utilities/CMakeLists.txt
@@ -98,7 +98,7 @@ ELSE()
   SET( PLATFORM_STRING "linux" )
 ENDIF()
 
-SET( DOWNLOAD_LINK "ftp://www.nitrc.org/home/groups/captk/downloads/Hausdorff95_${PLATFORM_STRING}.zip" )
+SET( DOWNLOAD_LINK "https://captk.projects.nitrc.org/Hausdorff95_${PLATFORM_STRING}.zip" )
 SET( FILENAME_TO_EXTRACT "hausdorff95_${PLATFORM_STRING}")
 SET( FILE_TO_EXTRACT ${PROJECT_BINARY_DIR}/${FILENAME_TO_EXTRACT}.zip)
 


### PR DESCRIPTION
Fixes the Dockerfile and some basic CMake related changes to ensure it builds.
I have confirmed that the entrypoint for BraTSPipeline now actually gets to BraTSPipeline.
I changed the workflow to no longer mount in the directory, it's simple now.

@sarthakpati You will need to ensure that the stuff actually works from here, I just made sure it builds (for instance we may need to install python or whatever).

There is still space for optimization here (like copying the install out of the builder image and into a new minimal image). This should be fairly simple to do but I don't yet know what a "minimal" centos install will look like yet or if the install binaries *rely* on the magic done in the packaging step.

I'll get back to you, but you should be able to work off of this without any problems.