### PR TITLE
MLCube: Support for GPUs and non-preprocessed NIfTI images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,6 +94,7 @@ RUN /nnunet_env/bin/pip install git+https://github.com/MIC-DKFZ/nnUNet.git@nnune
 
 ENV nnUNet_raw_data_base="/tmp/nnUNet_raw_data_base"
 ENV nnUNet_preprocessed="/tmp/nnUNet_preprocessed"
+ENV CUDA_VISIBLE_DEVICES="0"
 
 COPY ./mlcubes/data_preparation/project /project
 

--- a/mlcubes/data_preparation/project/statistics.py
+++ b/mlcubes/data_preparation/project/statistics.py
@@ -28,13 +28,26 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    dicom_info_file = "dicom_tag_information_to_write_anon.yaml"
-    dicom_info_filepath = os.path.join(args.metadata_path, dicom_info_file)
+    splits_path = os.path.join(args.data, "splits.csv")
+    invalid_path = os.path.join(args.metadata_path, ".invalid.txt")
 
-    stats = {}
-    if os.path.exists(dicom_info_filepath):
-        with open(dicom_info_filepath, "r") as f:
-            stats = yaml.safe_load(f)
+    invalid_subjects = []
+    if os.path.exists(invalid_path):
+        with open(invalid_path, "r") as f:
+            invalid_subjects = f.readlines()
+
+    splits_df = pd.read_csv(splits_path)
+
+    num_train_subjects = len(splits_df[splits_df["Split"] == "Train"])
+    num_val_subjects = len(splits_df[splits_df["Split"] == "Val"])
+
+    num_invalid_subjects = len(invalid_subjects)
+
+    stats = {
+        "num_train_subjects": num_train_subjects,
+        "num_val_subjects": num_val_subjects,
+        "num_invalid_subjects": num_invalid_subjects
+    }
 
     with open(args.out_file, "w") as f:
         yaml.dump(stats, f)

--- a/src/applications/CreateCSVForDICOMs.py
+++ b/src/applications/CreateCSVForDICOMs.py
@@ -1,4 +1,4 @@
-import os, argparse, sys, platform, posixpath
+import os, argparse, sys, platform, posixpath, re
 from pathlib import Path
 from datetime import date
 from tqdm import tqdm
@@ -124,12 +124,13 @@ class CSVCreator:
         for modality in modality_folders:
             modality_path = posixpath.join(timepoint_dir, modality)
             modality_lower = modality.lower()
+            modality_norm = re.sub('\.nii\.gz', '', modality_lower)
             for modality_to_check in MODALITY_ID_DICT:
                 if detected_modalities[modality_to_check] is not None:
                     continue
 
                 for modality_id in MODALITY_ID_DICT[modality_to_check]:
-                    if modality_id != modality_lower:
+                    if modality_id != modality_norm:
                         continue
 
                     valid_dicom, first_dicom_file = verify_dicom_folder(modality_path)


### PR DESCRIPTION
This PR makes the necessary changes for the Data Preparation MLCube to support hardware acceleration and working with non-preprocessed NIfTI files.

Additionally, this PR implements changes to the statistics algorithm such that it returns the number of cases per split, instead of DICOM statistics